### PR TITLE
Set static 'Bilgisaray' title for posts

### DIFF
--- a/src/_includes/base.liquid
+++ b/src/_includes/base.liquid
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
   	<meta name='viewport' content='width=device-width'>
 
-    <title>{{ title }}</title>
+    <title>Bilgisaray</title>
     <meta name='description' content={{ site.description }}>
     <meta name="theme-color" content="#ffffff"/>
 

--- a/src/_includes/post.liquid
+++ b/src/_includes/post.liquid
@@ -6,7 +6,7 @@ title: Bilgisaray
 {% include "nav.liquid" %}
 
 <p class="text-5xl md:text-6xl font-black pt-10 md:pt-30 pb-4 leading-tight">
-
+Bilgisaray
 </p>
 
 <div>


### PR DESCRIPTION
- Modified `base.liquid` to set the browser tab title to 'Bilgisaray'.
- Modified `post.liquid` to set the on-page display title to 'Bilgisaray' for all individual posts.
- Verified that post listing pages will continue to use the original titles from frontmatter.